### PR TITLE
Added file-type extensions for shortened URLs.

### DIFF
--- a/linkshortener.go
+++ b/linkshortener.go
@@ -23,10 +23,10 @@ type Shortener struct {
 // local webserver.
 func (shortener *Shortener) Shorten(url string) string {
 	var suffix = ""
-	var urlSuffix = regexp.MustCompile(`.*(\.\w{3,4}$)`)
+	var urlSuffix = regexp.MustCompile(`(http(s)?:\/\/)?.*(\.\w+)+\/.*(\.\w{1,4})$`)
 	var matches = urlSuffix.FindStringSubmatch(url)
-	if len(matches) > 1 {
-		suffix = matches[1]
+	if len(matches) > 0 {
+		suffix = matches[len(matches) - 1]
 	}
 
 	for id, address := range shortener.shortenedUrls {

--- a/tests/shortnotforlong_test.go
+++ b/tests/shortnotforlong_test.go
@@ -1,10 +1,10 @@
 package tests
 
 import (
-	"net/http"
-	"testing"
-
 	linkshortener "github.com/Bios-Marcel/shortnotforlong"
+	"net/http"
+	"strings"
+	"testing"
 )
 
 func TestShortener(t *testing.T) {
@@ -39,4 +39,23 @@ func TestShortener(t *testing.T) {
 			t.Errorf("URL was incorrect: %s", response.Request.URL.String())
 		}
 	}
+
+	{
+		suffix := ".png"
+		URL := "https://duckduckgo.com/img" + suffix
+		shortenedURL := shortener.Shorten(URL)
+		response, httpError := http.Head(shortenedURL)
+		if httpError != nil {
+			t.Fatalf("Error shortening looking up: '%s' (%s). Error: %s", shortenedURL, URL, httpError.Error())
+		}
+
+		if response.Request.URL.String() != URL {
+			t.Errorf("URL was incorrect: %s", response.Request.URL.String())
+		}
+
+		if !strings.HasSuffix(shortenedURL, suffix) {
+			t.Errorf("Shortened url does not end with: %s", suffix)
+		}
+	}
+
 }

--- a/tests/shortnotforlong_test.go
+++ b/tests/shortnotforlong_test.go
@@ -3,9 +3,12 @@ package tests
 import (
 	linkshortener "github.com/Bios-Marcel/shortnotforlong"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 )
+
+// URLs without a colon prefix (e.g. http://) are not supported by the go http library
 
 func TestShortener(t *testing.T) {
 	shortener := linkshortener.NewShortener(55555)
@@ -55,6 +58,43 @@ func TestShortener(t *testing.T) {
 
 		if !strings.HasSuffix(shortenedURL, suffix) {
 			t.Errorf("Shortened url does not end with: %s", suffix)
+		}
+	}
+
+	{
+		suffix := ".webm"
+		URL := "http://duckduckgo.com/vid" + suffix
+		shortenedURL := shortener.Shorten(URL)
+		response, httpError := http.Head(shortenedURL)
+		if httpError != nil {
+			t.Fatalf("Error shortening looking up: '%s' (%s). Error: %s", shortenedURL, URL, httpError.Error())
+		}
+
+		if response.Request.URL.String() != URL {
+			t.Errorf("URL was incorrect: %s", response.Request.URL.String())
+		}
+
+		if !strings.HasSuffix(shortenedURL, suffix) {
+			t.Errorf("Shortened url does not end with: %s", suffix)
+		}
+	}
+
+	{
+		URL := "https://github.com"
+		shortenedURL := shortener.Shorten(URL)
+		response, httpError := http.Head(shortenedURL)
+		if httpError != nil {
+			t.Fatalf("Error shortening looking up: '%s' (%s). Error: %s", shortenedURL, URL, httpError.Error())
+		}
+
+		if response.Request.URL.String() != URL {
+			t.Errorf("URL was incorrect: %s", response.Request.URL.String())
+		}
+
+		var urlSuffix = regexp.MustCompile(`.*(/\d+)$`)
+		var matches = urlSuffix.FindStringSubmatch(shortenedURL)
+		if len(matches) == 0 {
+			t.Errorf("Shortened url does not end with '/{number}' - %s", shortenedURL)
 		}
 	}
 


### PR DESCRIPTION
URLs that end with `\.\w{3,4}$` will have that suffix applied to the shortened URL.
This resolves #1  